### PR TITLE
Added support for highlighting of spans inside the filtered list and added some additional customizability options.

### DIFF
--- a/frameworks/foundation/views/combo_box.js
+++ b/frameworks/foundation/views/combo_box.js
@@ -763,7 +763,7 @@ SCUI.ComboBoxView = SC.View.extend( SC.Control, SC.Editable, {
                 if(this.get('highlightFilteredSpan')) {
                   var filter = this.getPath('comboBoxView.filter');
                   
-                  if(filter.length > 2) {
+                  if(filter.length > 1) {
                     label = label.replace(filter, '<span class="highlight-filtered-text">'+filter+'</span>');
                   }
                 }


### PR DESCRIPTION
I added some support that could be nice for using the SCUI.ComboBox element for autocomplete. First, I added a way to turn on highlighting of spans inside of the filtered results using a new property: 'highlightFilterOnListItem'. 

Then, I also added some customization options for changing the 'rowHeight' of the list view (it was hardcoded before) and also a custom picker class name: 'customPickerClassName' that can be applied for styling purposes since it pops up into a different pane.
