### PR TITLE
Implemented a drop to canvas feature, could be used to create new element

### DIFF
--- a/frameworks/linkit/mixins/terminal.js
+++ b/frameworks/linkit/mixins/terminal.js
@@ -353,7 +353,10 @@ LinkIt.Terminal = {
       // First, Check nodes for compatability
       var links = this._getLinkObjects(otherTerminal, otherNode, this, myNode);
       myNodeAccepted =  (myNode && links[0]) ? myNode.canLink( links[0] ) : NO;
-      otherNodeAccepted = (otherNode && myNodeAccepted && links[1]) ? otherNode.canLink( links[1] ) : NO;            
+      otherNodeAccepted = (otherNode && myNodeAccepted && links[1]) ? otherNode.canLink( links[1] ) : NO;
+    }
+    if (otherTerminal && otherTerminal.get('isCanvas')) {
+    	return otherTerminal.get('acceptCanvasDrop');
     }
     return (myNodeAccepted && otherNodeAccepted);
   },

--- a/frameworks/linkit/views/canvas.js
+++ b/frameworks/linkit/views/canvas.js
@@ -67,9 +67,50 @@ LinkIt.CanvasView = SC.CollectionView.extend({
   /**
   */
   displayProperties: ['frame'],
+
+  /**
+  * Easy to use detection of the canvas class
+  */
+  isCanvas : YES,
+  
+  //*** SC.DropTarget ***
+  /**
+  	Must be true when your view is instantiated.
+
+  	Drop targets must be specially registered in order to receive drop
+  	events.  SproutCore knows to register your view when this property
+  	is true on view creation.
+  */  
+  isDropTarget: YES,
   
   // PUBLIC METHODS
-
+  
+  /**
+   * You would need to override this function with your specific handler
+   * to handle Drops to the canvas.
+   */
+  acceptCanvasDrop: YES,
+  
+  computeDragOperations: function(drag, evt) {
+  	// Make it dependent on acceptCanvasDrop
+    return this.acceptCanvasDrop?SC.DRAG_LINK:SC.DRAG_NONE;
+  }, 
+  
+  /**
+   * Overridden perform drag operation so that CollectionView#performDragOperation will
+   * not get called.
+   * If you would like to implement a Canvas Drop to Create a new element
+   * just override this operation to do what you need to do 
+   * 
+   * @param drag
+   * @param op
+   * @returns
+   */
+  performDragOperation: function(drag, op) {
+  	return SC.DRAG_NONE;
+  },
+  
+ 
   /**
     Call this to trigger a links refresh
   */


### PR DESCRIPTION
Implemented a drop to canvas feature, could be used to create new elements by dragging a connector and dropping it to the empty canvas.

Demo video:

http://screencast.com/t/n1wxahvELO

To use it user should overload one function on her Canvas object that will be triggered when drop on canvas is happened.
